### PR TITLE
docs: Add Cursor and Claude Code MCP configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,76 @@ The following namespaces are automatically available:
 
 ## MCP Configuration
 
+### Cursor
+
+Add to your Cursor settings (`.cursor/mcp_settings.json` or via Settings UI):
+
+```json
+{
+  "mcpServers": {
+    "csharp-eval": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/infinityflowapp/csharp-mcp:latest"],
+      "env": {
+        "CSX_ALLOWED_PATH": "/scripts"
+      }
+    }
+  }
+}
+```
+
+Or if installed as a dotnet tool:
+
+```json
+{
+  "mcpServers": {
+    "csharp-eval": {
+      "command": "infinityflow-csharp-eval",
+      "env": {
+        "CSX_ALLOWED_PATH": "${workspaceFolder}/scripts"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to your Claude Code configuration (`claude_desktop_config.json`):
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "csharp-eval": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/infinityflowapp/csharp-mcp:latest"],
+      "env": {
+        "CSX_ALLOWED_PATH": "/scripts"
+      }
+    }
+  }
+}
+```
+
+Or if installed as a dotnet tool:
+
+```json
+{
+  "mcpServers": {
+    "csharp-eval": {
+      "command": "infinityflow-csharp-eval",
+      "env": {
+        "CSX_ALLOWED_PATH": "/Users/your-username/scripts"
+      }
+    }
+  }
+}
+```
+
 ### VS Code
 
 Create `.vscode/mcp.json`:


### PR DESCRIPTION
## Summary
- Added comprehensive MCP configuration instructions for Cursor
- Added comprehensive MCP configuration instructions for Claude Code  
- Included examples for both Docker and dotnet tool installations

## Changes
- Added Cursor configuration section with `.cursor/mcp_settings.json` examples
- Added Claude Code configuration section with platform-specific paths:
  - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
  - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
  - Linux: `~/.config/claude/claude_desktop_config.json`
- Included `CSX_ALLOWED_PATH` environment variable in examples for security
- Reorganized MCP configuration section to prioritize Cursor and Claude Code

## Test plan
- [x] Configuration examples are syntactically valid JSON
- [x] Paths follow platform conventions
- [x] Docker and dotnet tool commands are correct

🤖 Generated with [Claude Code](https://claude.ai/code)