### PR TITLE
fix: Use absolute path in Docker ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ ENV NUGET_PACKAGES=/tmp/csharp-mcp-packages
 ENV DOTNET_RUNNING_IN_CONTAINER=true
 
 # The MCP server uses stdio for communication
-ENTRYPOINT ["dotnet", "InfinityFlow.CSharp.Eval.dll"]
+ENTRYPOINT ["dotnet", "/app/InfinityFlow.CSharp.Eval.dll"]


### PR DESCRIPTION
## Summary
Fixes Docker container failing when MCP clients change the working directory.

## Problem
When Claude or Cursor uses the Docker image with `-w ${PWD}` to change the working directory, the container fails with:
```
Could not execute because the specified command or file was not found.
dotnet-InfinityFlow.CSharp.Eval.dll does not exist
```

## Solution
Use absolute path `/app/InfinityFlow.CSharp.Eval.dll` in the ENTRYPOINT so the application can be found regardless of working directory changes.

## Testing
```bash
# Build and test locally
docker build -t test-mcp .
docker run --rm -w /tmp test-mcp  # Should work now
```

## Impact
This is a critical fix for Docker-based MCP usage with Claude Desktop and Cursor.

🤖 Generated with [Claude Code](https://claude.ai/code)